### PR TITLE
Devops/ui docker

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -7,7 +7,8 @@ WORKDIR /app
 
 # install and cache app dependencies
 COPY /src /app/src 
-COPY ["package.json", "yarn.lock", "./"]
+COPY /public /app/public
+COPY ["package.json", "yarn.lock","tsconfig.json", "tsconfig.prod.json", "tslint.json", "./"]
 RUN yarn install
 RUN yarn build
 


### PR DESCRIPTION
This fixes the docker file so that it correctly builds the client.

With this change it is now possible to run `docker-compose up` in the root and start up the entire application. So fiddling will have to be done to setup the environment variables and to create the database though.