### PR TITLE
Fix client Docker build

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,5 +1,5 @@
 # base image
-FROM node:9.6.1 AS builder
+FROM node:10.16 AS builder
 
 # set working directory
 RUN mkdir /app

--- a/client/package.json
+++ b/client/package.json
@@ -38,6 +38,7 @@
     "prettier": "^1.16.4",
     "pretty-quick": "^1.10.0",
     "storybook": "^1.0.0",
+    "babel-loader": "8.0.5",
     "typescript": "3.4.5"
   },
   "husky": {

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -22,7 +22,7 @@ services:
     depends_on:
       - api
     environment:
-      NODE_ENV: dev
+      NODE_ENV: development
 
   client:
     build: client

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -14,9 +14,8 @@ services:
       - yarn
       - storybook
     volumes:
-      - ./client/src:/app/src:ro
-      - ./client/package.json:/app/package.json:ro
-      - ./client/tsconfig.json:/app/tsconfig.json:ro
+      - ./client:/app:ro
+      - /app/node_modules
     ports:
       - "9001:9001"
     depends_on:
@@ -30,9 +29,8 @@ services:
       - yarn
       - start
     volumes:
-      - ./client/src:/app/src:ro
-      - ./client/package.json:/app/package.json:ro
-      - ./client/tsconfig.json:/app/tsconfig.json:ro
+      - ./client:/app:ro
+      - /app/node_modules
     depends_on:
       - api
     environment:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -11,8 +11,7 @@ services:
   storybook:
     build: client
     command:
-      - npm
-      - run
+      - yarn
       - storybook
     volumes:
       - ./client/src:/app/src:ro


### PR DESCRIPTION
There is an incompatibility in node version that  fails the build for the client:

```
yarn install v1.3.2
[1/4] Resolving packages...
[2/4] Fetching packages...
error @typescript-eslint/eslint-plugin@1.6.0: The engine "node" is incompatible with this module. Expected version "^6.14.0 || ^8.10.0 || >=9.10.0".
error Found incompatible module
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
The command '/bin/sh -c yarn install' returned a non-zero code: 1
```
I upgraded the node version in the Dockerfile to 10.16 (>=9.10.0 not enough, for another module don't remember which) and now the build passes. 